### PR TITLE
Add storage bucket and messaging sender Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Crea un archivo `.env` (o configura en GitHub Pages → Repository Variables) co
 VITE_FIREBASE_API_KEY=xxxxx
 VITE_FIREBASE_AUTH_DOMAIN=xxxxx.firebaseapp.com
 VITE_FIREBASE_PROJECT_ID=xxxxx
+VITE_FIREBASE_STORAGE_BUCKET=xxxxx.firebasestorage.app
+VITE_FIREBASE_MESSAGING_SENDER_ID=xxxxxxxxxxxx
 VITE_FIREBASE_APP_ID=1:xxxx:web:xxxx
 # Opcional para despliegues en subdirectorios (GitHub Pages)
 VITE_PUBLIC_BASE_PATH=/qualitybordados.github.io/

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -6,6 +6,8 @@ const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY as string,
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN as string,
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID as string,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET as string,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID as string,
   appId: import.meta.env.VITE_FIREBASE_APP_ID as string,
 }
 


### PR DESCRIPTION
## Summary
- include Firebase storage bucket and messaging sender values in the runtime config
- document the new required environment variables in the README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d85d0774b48325be47abf238ec428c