### PR TITLE
Delay data fetching until auth is ready

### DIFF
--- a/src/features/caja/hooks.ts
+++ b/src/features/caja/hooks.ts
@@ -11,11 +11,16 @@ type CajaFilters = {
   hasta?: Date
 }
 
-export function useMovimientosCaja(filters: CajaFilters = {}) {
+type CajaQueryOptions = {
+  enabled?: boolean
+}
+
+export function useMovimientosCaja(filters: CajaFilters = {}, options: CajaQueryOptions = {}) {
   return useQuery({
     queryKey: [...CAJA_KEY, filters],
     queryFn: () => fetchMovimientosCaja(filters),
     staleTime: 1000 * 30,
+    enabled: options.enabled,
   })
 }
 

--- a/src/features/clientes/hooks.ts
+++ b/src/features/clientes/hooks.ts
@@ -10,11 +10,16 @@ type ClientesFilters = {
   estatus?: string
 }
 
-export function useClientes(filters: ClientesFilters = {}) {
+type ClientesQueryOptions = {
+  enabled?: boolean
+}
+
+export function useClientes(filters: ClientesFilters = {}, options: ClientesQueryOptions = {}) {
   return useQuery({
     queryKey: [...CLIENTES_KEY, filters],
     queryFn: () => fetchClientes(filters),
     staleTime: 1000 * 60,
+    enabled: options.enabled,
   })
 }
 

--- a/src/features/cobranza/hooks.ts
+++ b/src/features/cobranza/hooks.ts
@@ -4,11 +4,16 @@ import { AbonoForm } from '@/lib/validators'
 
 const COBRANZA_KEY = ['cobranza']
 
-export function usePedidosConSaldo() {
+type CobranzaQueryOptions = {
+  enabled?: boolean
+}
+
+export function usePedidosConSaldo(options: CobranzaQueryOptions = {}) {
   return useQuery({
     queryKey: COBRANZA_KEY,
     queryFn: fetchPedidosConSaldo,
     staleTime: 1000 * 30,
+    enabled: options.enabled,
   })
 }
 

--- a/src/features/configuracion/hooks.ts
+++ b/src/features/configuracion/hooks.ts
@@ -4,11 +4,16 @@ import { ConfiguracionForm } from '@/lib/validators'
 
 const CONFIG_KEY = ['configuracion']
 
-export function useConfiguracion() {
+type ConfigQueryOptions = {
+  enabled?: boolean
+}
+
+export function useConfiguracion(options: ConfigQueryOptions = {}) {
   return useQuery({
     queryKey: CONFIG_KEY,
     queryFn: fetchConfiguracion,
     staleTime: 1000 * 60 * 5,
+    enabled: options.enabled,
   })
 }
 

--- a/src/features/dashboard/hooks.ts
+++ b/src/features/dashboard/hooks.ts
@@ -1,10 +1,15 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchDashboardData } from './api'
 
-export function useDashboardData() {
+type DashboardQueryOptions = {
+  enabled?: boolean
+}
+
+export function useDashboardData(options: DashboardQueryOptions = {}) {
   return useQuery({
     queryKey: ['dashboard'],
     queryFn: fetchDashboardData,
     staleTime: 1000 * 60,
+    enabled: options.enabled,
   })
 }

--- a/src/features/pedidos/hooks.ts
+++ b/src/features/pedidos/hooks.ts
@@ -11,11 +11,16 @@ type PedidosFilters = {
   clienteId?: string
 }
 
-export function usePedidos(filters: PedidosFilters = {}) {
+type PedidosQueryOptions = {
+  enabled?: boolean
+}
+
+export function usePedidos(filters: PedidosFilters = {}, options: PedidosQueryOptions = {}) {
   return useQuery({
     queryKey: [...PEDIDOS_KEY, filters],
     queryFn: () => fetchPedidos(filters),
     staleTime: 1000 * 30,
+    enabled: options.enabled,
   })
 }
 

--- a/src/pages/app/caja.tsx
+++ b/src/pages/app/caja.tsx
@@ -14,18 +14,29 @@ import { EmptyState } from '@/components/common/empty-state'
 import { MovimientoCajaForm } from '@/lib/validators'
 
 export default function CajaPage() {
-  const { user, role } = useAuth()
+  const { user, role, loading } = useAuth()
   const [tipoFiltro, setTipoFiltro] = useState<'INGRESO' | 'EGRESO' | 'TODOS'>('TODOS')
   const [categoriaFiltro, setCategoriaFiltro] = useState('')
   const [fechaInicio, setFechaInicio] = useState(dayjs().subtract(7, 'day').format('YYYY-MM-DD'))
   const [fechaFin, setFechaFin] = useState(dayjs().format('YYYY-MM-DD'))
 
-  const { data: movimientos, isLoading } = useMovimientosCaja({
-    tipo: tipoFiltro,
-    categoria: categoriaFiltro || undefined,
-    desde: dayjs(fechaInicio).toDate(),
-    hasta: dayjs(fechaFin).toDate(),
-  })
+  const authReady = !!user && !loading
+
+  const {
+    data: movimientos,
+    isLoading,
+    isFetching,
+  } = useMovimientosCaja(
+    {
+      tipo: tipoFiltro,
+      categoria: categoriaFiltro || undefined,
+      desde: dayjs(fechaInicio).toDate(),
+      hasta: dayjs(fechaFin).toDate(),
+    },
+    { enabled: authReady },
+  )
+
+  const loadingMovimientos = loading || isLoading || (authReady && isFetching && !movimientos)
 
   const crearMovimiento = useCrearMovimientoCaja()
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -167,7 +178,7 @@ export default function CajaPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {isLoading ? (
+              {loadingMovimientos ? (
                 <TableRow>
                   <TableCell colSpan={6} className="py-10 text-center text-sm text-slate-500">
                     <Loader2 className="mx-auto h-5 w-5 animate-spin" />

--- a/src/pages/app/clientes.tsx
+++ b/src/pages/app/clientes.tsx
@@ -19,10 +19,16 @@ import { Loader2, Plus, Search, Trash } from 'lucide-react'
 const estatusFilters = ['TODOS', 'ACTIVO', 'PAUSADO']
 
 export default function ClientesPage() {
-  const { role, user } = useAuth()
+  const { role, user, loading } = useAuth()
   const [search, setSearch] = useState('')
   const [estatus, setEstatus] = useState<string>('TODOS')
-  const { data: clientes, isLoading } = useClientes({ search, estatus })
+  const authReady = !!user && !loading
+  const {
+    data: clientes,
+    isLoading,
+    isFetching,
+  } = useClientes({ search, estatus }, { enabled: authReady })
+  const clientesLoading = loading || isLoading || (authReady && isFetching && !clientes)
   const createMutation = useCreateCliente()
   const updateMutation = useUpdateCliente()
   const deleteMutation = useDeleteCliente()
@@ -142,7 +148,7 @@ export default function ClientesPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {isLoading ? (
+              {clientesLoading ? (
                 <TableRow>
                   <TableCell colSpan={6} className="py-10 text-center text-sm text-slate-500">
                     <Loader2 className="mx-auto h-5 w-5 animate-spin" />
@@ -213,7 +219,9 @@ export default function ClientesPage() {
 }
 
 function ClienteDetalle({ cliente, puedeEliminar, onEliminar }: { cliente: Cliente; puedeEliminar: boolean; onEliminar: (cliente: Cliente) => void }) {
-  const { data: pedidos } = usePedidos({ clienteId: cliente.id })
+  const { user, loading } = useAuth()
+  const authReady = !!user && !loading
+  const { data: pedidos } = usePedidos({ clienteId: cliente.id }, { enabled: authReady })
   const saldoTotal = useMemo(() => {
     if (!pedidos) return 0
     return pedidos.reduce((sum, pedido) => sum + pedido.saldo, 0)

--- a/src/pages/app/cobranza.tsx
+++ b/src/pages/app/cobranza.tsx
@@ -17,9 +17,11 @@ import { AbonoForm as AbonoFormValues } from '@/lib/validators'
 const metodosPago = ['EFECTIVO', 'TRANSFERENCIA', 'TARJETA'] as const
 
 export default function CobranzaPage() {
-  const { data: pedidos, isLoading } = usePedidosConSaldo()
+  const { user, role, loading } = useAuth()
+  const authReady = !!user && !loading
+  const { data: pedidos, isLoading, isFetching } = usePedidosConSaldo({ enabled: authReady })
+  const pedidosLoading = loading || isLoading || (authReady && isFetching && !pedidos)
   const registrarAbono = useRegistrarAbono()
-  const { user, role } = useAuth()
   const [pedidoSeleccionado, setPedidoSeleccionado] = useState<any | null>(null)
 
   const puedeRegistrar = ['OWNER', 'ADMIN', 'COBRANZA'].includes(role ?? '')
@@ -43,7 +45,7 @@ export default function CobranzaPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {isLoading ? (
+              {pedidosLoading ? (
                 <TableRow>
                   <TableCell colSpan={6} className="py-10 text-center text-sm text-slate-500">
                     <Loader2 className="mx-auto h-5 w-5 animate-spin" />

--- a/src/pages/app/config.tsx
+++ b/src/pages/app/config.tsx
@@ -15,8 +15,10 @@ import { Loader2 } from 'lucide-react'
 const roles = ['OWNER', 'ADMIN', 'VENTAS', 'PRODUCCION', 'COBRANZA'] as const
 
 export default function ConfiguracionPage() {
-  const { role, user } = useAuth()
-  const { data, isLoading } = useConfiguracion()
+  const { role, user, loading } = useAuth()
+  const authReady = !!user && !loading
+  const { data, isLoading, isFetching } = useConfiguracion({ enabled: authReady })
+  const configuracionLoading = loading || isLoading || (authReady && isFetching && !data)
   const guardarConfiguracion = useGuardarConfiguracion()
 
   const form = useForm<ConfiguracionForm>({
@@ -42,7 +44,7 @@ export default function ConfiguracionPage() {
     await guardarConfiguracion.mutateAsync({ data: values, usuarioId: user.uid })
   }
 
-  if (isLoading) {
+  if (configuracionLoading) {
     return (
       <div className="flex h-40 items-center justify-center">
         <Loader2 className="h-6 w-6 animate-spin" />

--- a/src/pages/app/dashboard.tsx
+++ b/src/pages/app/dashboard.tsx
@@ -4,11 +4,15 @@ import { formatCurrency, formatDate } from '@/lib/format'
 import { Alert } from '@/components/ui/alert'
 import { EmptyState } from '@/components/common/empty-state'
 import { ResponsiveContainer, BarChart, Bar, CartesianGrid, XAxis, YAxis, Tooltip, LineChart, Line } from 'recharts'
+import { useAuth } from '@/hooks/use-auth'
 
 export default function DashboardPage() {
-  const { data, isLoading, isError } = useDashboardData()
+  const { user, loading } = useAuth()
+  const authReady = !!user && !loading
+  const { data, isLoading, isFetching, isError } = useDashboardData({ enabled: authReady })
+  const dashboardLoading = loading || isLoading || (authReady && isFetching && !data)
 
-  if (isLoading) {
+  if (dashboardLoading) {
     return (
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         {Array.from({ length: 4 }).map((_, index) => (
@@ -25,7 +29,7 @@ export default function DashboardPage() {
     )
   }
 
-  if (isError || !data) {
+  if ((isError && authReady) || !data) {
     return <Alert variant="destructive" title="No fue posible cargar el tablero" description="Reintenta en unos segundos." />
   }
 

--- a/src/pages/app/pedidos.tsx
+++ b/src/pages/app/pedidos.tsx
@@ -33,12 +33,18 @@ const estadosPedido: PedidoEstado[] = [
 const prioridades: Prioridad[] = ['BAJA', 'MEDIA', 'ALTA']
 
 export default function PedidosPage() {
-  const { user, role } = useAuth()
-  const { data: pedidos, isLoading } = usePedidos()
+  const { user, role, loading } = useAuth()
+  const authReady = !!user && !loading
+  const {
+    data: pedidos,
+    isLoading,
+    isFetching,
+  } = usePedidos({}, { enabled: authReady })
+  const pedidosLoading = loading || isLoading || (authReady && isFetching && !pedidos)
   const createPedido = useCreatePedido()
   const actualizarEstado = useActualizarEstadoPedido()
-  const { data: clientesData } = useClientes()
-  const { data: config } = useConfiguracion()
+  const { data: clientesData } = useClientes({}, { enabled: authReady })
+  const { data: config } = useConfiguracion({ enabled: authReady })
 
   const [wizardOpen, setWizardOpen] = useState(false)
   const [detallePedido, setDetallePedido] = useState<any | null>(null)
@@ -99,7 +105,7 @@ export default function PedidosPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {isLoading ? (
+              {pedidosLoading ? (
                 <TableRow>
                   <TableCell colSpan={7} className="py-10 text-center">
                     <Loader2 className="mx-auto h-5 w-5 animate-spin text-slate-500" />


### PR DESCRIPTION
## Summary
- add optional enabled flags to shared data fetching hooks so queries can be deferred
- wait for authentication to resolve before running dashboard and management queries to avoid unauthorized Firestore access
- keep existing loading indicators active while auth state is loading to provide consistent feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9e6ad6eb08325aa48bd448e81231d