### PR TITLE
Add missing dialog descriptions for accessibility

### DIFF
--- a/src/pages/app/caja.tsx
+++ b/src/pages/app/caja.tsx
@@ -5,7 +5,7 @@ import { Button } from '@/components/ui/button'
 import { useMovimientosCaja, useCrearMovimientoCaja } from '@/features/caja/hooks'
 import { useAuth } from '@/hooks/use-auth'
 import { formatCurrency, formatDate } from '@/lib/format'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { Loader2, Download, Plus } from 'lucide-react'
@@ -120,6 +120,7 @@ export default function CajaPage() {
                 <DialogContent>
                   <DialogHeader>
                     <DialogTitle>Registrar movimiento</DialogTitle>
+                    <DialogDescription>Captura un ingreso o egreso y guarda la referencia en la bitácora.</DialogDescription>
                   </DialogHeader>
                   <MovimientoForm
                     onSubmit={async (values) => {

--- a/src/pages/app/clientes.tsx
+++ b/src/pages/app/clientes.tsx
@@ -9,7 +9,7 @@ import { useClientes, useCreateCliente, useDeleteCliente, useUpdateCliente } fro
 import { usePedidos } from '@/features/pedidos/hooks'
 import { Cliente } from '@/lib/types'
 import { formatCurrency, formatPhone } from '@/lib/format'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useAuth } from '@/hooks/use-auth'
 import { Alert } from '@/components/ui/alert'
@@ -122,6 +122,11 @@ export default function ClientesPage() {
               <DialogContent className="max-h-[80vh] overflow-y-auto">
                 <DialogHeader>
                   <DialogTitle>{clienteSeleccionado ? 'Editar cliente' : 'Nuevo cliente'}</DialogTitle>
+                  <DialogDescription>
+                    {clienteSeleccionado
+                      ? 'Actualiza los datos del cliente y guarda los cambios registrados.'
+                      : 'Completa la información para registrar un nuevo cliente en el sistema.'}
+                  </DialogDescription>
                 </DialogHeader>
                 <ClienteFormFields
                   defaultValues={clienteSeleccionado ?? undefined}
@@ -230,10 +235,10 @@ function ClienteDetalle({ cliente, puedeEliminar, onEliminar }: { cliente: Clien
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="text-xl font-semibold text-slate-900">{cliente.alias}</h2>
-          <p className="text-sm text-slate-500">{cliente.nombre_legal}</p>
-        </div>
+        <DialogHeader className="items-start text-left">
+          <DialogTitle className="text-xl font-semibold text-slate-900">{cliente.alias}</DialogTitle>
+          <DialogDescription>{cliente.nombre_legal}</DialogDescription>
+        </DialogHeader>
         {puedeEliminar ? (
           <Button variant="destructive" size="sm" onClick={() => onEliminar(cliente)}>
             <Trash className="mr-2 h-4 w-4" /> Eliminar

--- a/src/pages/app/cobranza.tsx
+++ b/src/pages/app/cobranza.tsx
@@ -6,7 +6,7 @@ import { useAuth } from '@/hooks/use-auth'
 import { formatCurrency, formatDate } from '@/lib/format'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import dayjs from 'dayjs'
@@ -125,6 +125,7 @@ function AbonoDialogForm({
     <div className="space-y-4">
       <DialogHeader>
         <DialogTitle>Registrar abono — {pedido.folio}</DialogTitle>
+        <DialogDescription>Ingresa el pago recibido y actualiza el saldo pendiente del pedido.</DialogDescription>
       </DialogHeader>
       <div className="space-y-3 text-sm">
         <div>

--- a/src/pages/app/pedidos.tsx
+++ b/src/pages/app/pedidos.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { usePedidos, useCreatePedido, useActualizarEstadoPedido } from '@/features/pedidos/hooks'
 import { useClientes } from '@/features/clientes/hooks'
 import { useConfiguracion } from '@/features/configuracion/hooks'
@@ -263,6 +263,7 @@ function PedidoWizard({
     <div className="space-y-6">
       <DialogHeader>
         <DialogTitle>Nuevo pedido</DialogTitle>
+        <DialogDescription>Completa los pasos para generar el pedido y calcular los importes finales.</DialogDescription>
       </DialogHeader>
       <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-slate-400">
         <span className={step === 1 ? 'font-semibold text-primary' : ''}>Cliente</span>
@@ -483,6 +484,7 @@ function DetallePedido({ pedido }: { pedido: any }) {
     <div className="space-y-4">
       <DialogHeader>
         <DialogTitle>Detalle pedido {pedido.folio}</DialogTitle>
+        <DialogDescription>Revisa la información general del pedido y su estado actual.</DialogDescription>
       </DialogHeader>
       <div className="grid gap-3 text-sm md:grid-cols-2">
         <div>


### PR DESCRIPTION
## Summary
- add dialog descriptions and titles across Caja, Clientes, Cobranza and Pedidos pages to address accessibility warnings

## Testing
- npm run lint *(fails: pre-existing lint/type errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e9479d9483258e078ce5b1f14de4