### PR TITLE
Update Firestore rules to be ready for Firestore console

### DIFF
--- a/firestore.rules.json
+++ b/firestore.rules.json
@@ -1,3 +1,28 @@
-{
-  "rules": "rules_version = '2';\nservice cloud.firestore {\n  match /databases/{database}/documents {\n    // Public documents readable by anyone\n    match /publicContent/{document=**} {\n      allow read: if true;\n      allow write: if request.auth != null && request.auth.token.admin == true;\n    }\n\n    // Authenticated users can access their own documents\n    match /users/{userId}/{document=**} {\n      allow read, write: if request.auth != null && request.auth.uid == userId;\n    }\n\n    // Allow authenticated users to create support tickets; only owners and admins can read/update\n    match /supportTickets/{ticketId} {\n      allow create: if request.auth != null;\n      allow read, update, delete: if request.auth != null && (request.auth.uid == resource.data.ownerId || request.auth.token.admin == true);\n    }\n\n    // Default deny; only admins can access other collections\n    match /{document=**} {\n      allow read, write: if request.auth != null && request.auth.token.admin == true;\n    }\n  }\n}"
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Public documents readable by anyone
+    match /publicContent/{document=**} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.admin == true;
+    }
+
+    // Authenticated users can access their own documents
+    match /users/{userId}/{document=**} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+
+    // Allow authenticated users to create support tickets; only owners and admins can read/update
+    match /supportTickets/{ticketId} {
+      allow create: if request.auth != null;
+      allow read, update, delete:
+          if request.auth != null &&
+             (request.auth.uid == resource.data.ownerId || request.auth.token.admin == true);
+    }
+
+    // Default deny; only admins can access other collections
+    match /{document=**} {
+      allow read, write: if request.auth != null && request.auth.token.admin == true;
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- replace the JSON-wrapped rules content with plain Firestore security rules syntax
- ensure the firestore.rules.json file can be copied directly into the Firestore console

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ec4e8d8483258281e001570ea56a