### PR TITLE
Use hash-based routing for GitHub Pages compatibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,8 +12,17 @@
 
         try {
           const targetUrl = new URL(redirectPath, window.location.origin)
-          const newPath = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`
-          window.history.replaceState(null, '', newPath)
+          const hasExplicitHash = targetUrl.hash && targetUrl.hash !== '#'
+          const normalizedPath = targetUrl.pathname.replace(/^\//, '')
+          const pathWithSearch = `${normalizedPath}${targetUrl.search}`
+          const nextHash = hasExplicitHash
+            ? targetUrl.hash.replace(/^#/, '')
+            : pathWithSearch
+
+          if (nextHash) {
+            const hashWithLeadingSlash = nextHash.startsWith('/') ? nextHash : `/${nextHash}`
+            window.location.hash = hashWithLeadingSlash
+          }
         } catch (error) {
           console.warn('[SPA Redirect] Failed to parse redirect path', error)
           sessionStorage.removeItem('gh-spa-redirect')

--- a/index.html
+++ b/index.html
@@ -12,8 +12,17 @@
 
         try {
           const targetUrl = new URL(redirectPath, window.location.origin)
-          const newPath = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`
-          window.history.replaceState(null, '', newPath)
+          const hasExplicitHash = targetUrl.hash && targetUrl.hash !== '#'
+          const normalizedPath = targetUrl.pathname.replace(/^\//, '')
+          const pathWithSearch = `${normalizedPath}${targetUrl.search}`
+          const nextHash = hasExplicitHash
+            ? targetUrl.hash.replace(/^#/, '')
+            : pathWithSearch
+
+          if (nextHash) {
+            const hashWithLeadingSlash = nextHash.startsWith('/') ? nextHash : `/${nextHash}`
+            window.location.hash = hashWithLeadingSlash
+          }
         } catch (error) {
           console.warn('[SPA Redirect] Failed to parse redirect path', error)
           sessionStorage.removeItem('gh-spa-redirect')

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
 import './index.css'
@@ -19,9 +19,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- switch the app to HashRouter so navigation stays under the root GitHub Pages domain
- normalize the SPA redirect helper to rewrite stored paths into hash-based routes in both index.html files

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9f24376008325ba62b32b0f0d2ee7