### PR TITLE
Improve mobile responsiveness across app

### DIFF
--- a/src/components/layout/app-shell.tsx
+++ b/src/components/layout/app-shell.tsx
@@ -29,7 +29,7 @@ export function AppShell() {
   }
 
   return (
-    <div className="relative flex min-h-screen bg-slate-100">
+    <div className="relative flex min-h-screen w-full max-w-[100vw] bg-slate-100">
       <div
         className={clsx(
           'fixed inset-0 z-40 bg-slate-900/40 backdrop-blur-sm transition-opacity lg:hidden',
@@ -96,7 +96,7 @@ export function AppShell() {
         </div>
       </aside>
 
-      <div className="flex min-h-screen flex-1 flex-col lg:pl-72">
+      <div className="flex min-h-screen w-full flex-1 flex-col lg:pl-72">
         <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-slate-200 bg-primary px-4 text-primary-foreground shadow-sm sm:px-6 lg:px-10">
           <div className="flex items-center gap-3">
             <Button

--- a/src/index.css
+++ b/src/index.css
@@ -6,10 +6,15 @@
   color-scheme: light;
 }
 
+html,
+body {
+  @apply h-full max-w-full overflow-x-hidden;
+}
+
 body {
   @apply bg-slate-50 font-sans text-[15px] leading-relaxed text-slate-900 antialiased;
 }
 
 #root {
-  @apply min-h-screen;
+  @apply min-h-screen w-full;
 }

--- a/src/pages/app/clientes.tsx
+++ b/src/pages/app/clientes.tsx
@@ -92,8 +92,8 @@ export default function ClientesPage() {
           <p className="text-xs text-slate-500">Gestiona tus clientes desde una vista táctil y rápida.</p>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="relative flex-1">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <div className="relative w-full sm:flex-1">
               <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
               <Input
                 placeholder="Buscar por nombre, alias, correo o ciudad"
@@ -102,12 +102,12 @@ export default function ClientesPage() {
                 onChange={(event) => setSearch(event.target.value)}
               />
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-3">
               <Filter className="hidden h-4 w-4 text-slate-400 sm:block" />
               <select
                 value={estatus}
                 onChange={(event) => setEstatus(event.target.value)}
-                className="h-11 rounded-full border border-slate-200 bg-white px-4 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                className="h-11 w-full rounded-full border border-slate-200 bg-white px-4 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent sm:w-auto"
               >
                 {estatusFilters.map((option) => (
                   <option key={option} value={option}>
@@ -118,7 +118,7 @@ export default function ClientesPage() {
               <select
                 value={ciudadFiltro}
                 onChange={(event) => setCiudadFiltro(event.target.value)}
-                className="h-11 rounded-full border border-slate-200 bg-white px-4 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent"
+                className="h-11 w-full rounded-full border border-slate-200 bg-white px-4 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-accent sm:w-auto"
               >
                 <option value="">Todas las ciudades</option>
                 {ciudades.map((ciudad) => (
@@ -250,7 +250,7 @@ function ClienteCard({
       </div>
 
       <div className="mt-4 space-y-3 text-sm text-slate-600">
-        <div className="flex flex-wrap items-center gap-3">
+        <div className="flex flex-col gap-2 text-slate-600 sm:flex-row sm:flex-wrap sm:items-center">
           <span className="flex items-center gap-2 text-slate-600">
             <Mail className="h-4 w-4 text-slate-400" />
             {cliente.email}
@@ -260,12 +260,12 @@ function ClienteCard({
             {formatPhone(cliente.telefono)}
           </span>
         </div>
-        <div className="flex flex-wrap items-center gap-3 text-slate-500">
-          <span className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 text-xs text-slate-500 sm:flex-row sm:flex-wrap sm:items-center">
+          <span className="flex items-center gap-2 text-slate-500">
             <MapPin className="h-4 w-4 text-slate-400" />
             {cliente.ciudad}
           </span>
-          <span className="flex items-center gap-2">
+          <span className="flex items-center gap-2 text-slate-500">
             <CreditCard className="h-4 w-4 text-slate-400" />
             {formatCurrency(cliente.limite_credito)} límite
           </span>

--- a/src/pages/app/cobranza.tsx
+++ b/src/pages/app/cobranza.tsx
@@ -111,7 +111,7 @@ function CobranzaCard({
       </div>
 
       <div className="mt-4 flex flex-col gap-2 text-sm text-slate-600">
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2 text-slate-500">
             <Calendar className="h-4 w-4 text-slate-400" />
             {formatDate(fecha)}
@@ -126,7 +126,7 @@ function CobranzaCard({
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-end">
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
         <Button onClick={onRegistrar} disabled={disabled} className="w-full sm:w-auto">
           Registrar abono
         </Button>

--- a/src/pages/app/pedidos.tsx
+++ b/src/pages/app/pedidos.tsx
@@ -203,7 +203,7 @@ function PedidoCard({
           <User className="h-4 w-4 text-slate-400" />
           {pedido.cliente_id.id}
         </div>
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex items-center gap-2 text-slate-500">
             <Calendar className="h-4 w-4 text-slate-400" />
             {formatDate(fechaCompromiso)}
@@ -214,7 +214,7 @@ function PedidoCard({
         </div>
       </div>
 
-      <div className="mt-4 flex items-center justify-between gap-3">
+      <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2 text-base font-semibold text-slate-900">
           <DollarSign className="h-4 w-4 text-slate-400" />
           {formatCurrency(pedido.saldo)}


### PR DESCRIPTION
## Summary
- prevent horizontal overflow by constraining the app shell width and updating global layout defaults
- stack search filters and client contact/metadata blocks into vertical cards on small screens
- align pedidos and cobranza action rows for touch-friendly spacing across breakpoints

## Testing
- npm run lint *(fails: existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d9ff2b5cfc83259e874ce36658ae2d