### PR TITLE
Fix docs asset script path for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
         document.head.appendChild(stylesheet)
       }
     </script>
-    <script type="module" crossorigin src="/assets/main.DCjV3JoR.js"></script>
+    <script type="module" crossorigin src="assets/main.DCjV3JoR.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update the docs index page to load the built JavaScript bundle using a relative path so GitHub Pages can resolve it correctly

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68dacc3216bc8325b9ce55789776a5fe