### PR TITLE
Fix docs asset loading path for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -191,7 +191,7 @@
         void ensureStylesheets()
       }
     </script>
-    <script type="module" crossorigin src="/assets/main.DMYkLxjH.js"></script>
+    <script type="module" crossorigin src="assets/main.DMYkLxjH.js"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- ensure the publish script normalizes the main bundle reference to a relative assets path
- update the built docs index to use the relative bundle path so GitHub Pages can load it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad450291c8325a92a13619f53d208