### PR TITLE
Fix escapeRegExp regex in docs tasks

### DIFF
--- a/scripts/tasks.mjs
+++ b/scripts/tasks.mjs
@@ -70,7 +70,7 @@ export async function cleanDocs() {
 }
 
 function escapeRegExp(input) {
-  return input.replace(/[.*+?^${}()|[\]\]/g, '\\$&')
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 async function rewriteCssReference(filePath, cssReference) {


### PR DESCRIPTION
## Summary
- correct the escapeRegExp helper so backslashes are properly escaped when building docs

## Testing
- npm run build
- npm run verify:docs

------
https://chatgpt.com/codex/tasks/task_e_68dad81123c48325a0984cd4b2594deb