### PR TITLE
Add abono details to pedido summary and PDF

### DIFF
--- a/src/features/pedidos/api.ts
+++ b/src/features/pedidos/api.ts
@@ -14,9 +14,9 @@ import {
   writeBatch,
 } from 'firebase/firestore'
 import { db } from '@/config/firebase'
-import { Pedido, PedidoEstado, PedidoItem, ProduccionEvento } from '@/lib/types'
+import { Abono, Pedido, PedidoEstado, PedidoItem, ProduccionEvento } from '@/lib/types'
 import { PedidoForm } from '@/lib/validators'
-import { movimientosCajaCollection, pedidoItemsCollection, registrarBitacora } from '@/lib/firestore'
+import { abonosCollection, movimientosCajaCollection, pedidoItemsCollection, registrarBitacora } from '@/lib/firestore'
 
 const pedidosRef = collection(db, 'pedidos')
 
@@ -53,6 +53,27 @@ export async function fetchPedidoItems(pedidoId: string) {
       precio_unitario: data.precio_unitario,
       importe: data.importe,
     } satisfies PedidoItem
+  })
+}
+
+export async function fetchPedidoAbonos(pedidoId: string) {
+  const pedidoRef = doc(db, 'pedidos', pedidoId)
+  const q = query(abonosCollection, where('pedido_id', '==', pedidoRef), orderBy('fecha', 'desc'))
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map((docSnap) => {
+    const data = docSnap.data()
+    return {
+      id: docSnap.id,
+      pedido_id: data.pedido_id,
+      cliente_id: data.cliente_id,
+      fecha: data.fecha,
+      monto: data.monto,
+      metodo: data.metodo,
+      ref: data.ref ?? '',
+      notas: data.notas ?? '',
+      registrado_por: data.registrado_por,
+      creado_en: data.creado_en,
+    } satisfies Abono
   })
 }
 

--- a/src/features/pedidos/hooks.ts
+++ b/src/features/pedidos/hooks.ts
@@ -1,5 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { actualizarEstadoPedido, createPedido, eliminarPedido, fetchPedidoItems, fetchPedidos, updatePedido } from './api'
+import {
+  actualizarEstadoPedido,
+  createPedido,
+  eliminarPedido,
+  fetchPedidoAbonos,
+  fetchPedidoItems,
+  fetchPedidos,
+  updatePedido,
+} from './api'
 import { PedidoEstado } from '@/lib/types'
 import { PedidoForm } from '@/lib/validators'
 
@@ -28,6 +36,15 @@ export function usePedidoItems(pedidoId?: string, options: { enabled?: boolean }
   return useQuery({
     queryKey: [...PEDIDOS_KEY, 'items', pedidoId],
     queryFn: () => fetchPedidoItems(pedidoId as string),
+    enabled: !!pedidoId && options.enabled,
+    staleTime: 1000 * 30,
+  })
+}
+
+export function usePedidoAbonos(pedidoId?: string, options: { enabled?: boolean } = {}) {
+  return useQuery({
+    queryKey: [...PEDIDOS_KEY, 'abonos', pedidoId],
+    queryFn: () => fetchPedidoAbonos(pedidoId as string),
     enabled: !!pedidoId && options.enabled,
     staleTime: 1000 * 30,
   })

--- a/src/types/pdf-lib.d.ts
+++ b/src/types/pdf-lib.d.ts
@@ -1,0 +1,20 @@
+declare module 'pdf-lib' {
+  export const StandardFonts: Record<string, string>
+  export function rgb(r: number, g: number, b: number): { r: number; g: number; b: number }
+
+  export interface PDFFont {
+    widthOfTextAtSize(text: string, size: number): number
+  }
+
+  export interface PDFPage {
+    drawText(text: string, options: Record<string, unknown>): void
+    drawRectangle(options: Record<string, unknown>): void
+  }
+
+  export class PDFDocument {
+    static create(): Promise<PDFDocument>
+    addPage(size?: [number, number]): PDFPage
+    embedFont(font: string): Promise<PDFFont>
+    save(): Promise<Uint8Array>
+  }
+}


### PR DESCRIPTION
## Summary
- load recorded abonos for each pedido through a dedicated API call and hook
- surface abonos in the pedido detail modal, including totals and individual entries
- update the PDF generator to include abonos and add local pdf-lib type declarations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db6ca938a08325baa3e4d6fdd1deaf