### PR TITLE
Fix abono list refresh after payment registration

### DIFF
--- a/src/features/cobranza/hooks.ts
+++ b/src/features/cobranza/hooks.ts
@@ -21,9 +21,10 @@ export function useRegistrarAbono() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (payload: { data: AbonoForm; usuarioId: string }) => registrarAbonoPedido(payload.data, payload.usuarioId),
-    onSuccess: () => {
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({ queryKey: COBRANZA_KEY })
       queryClient.invalidateQueries({ queryKey: ['pedidos'] })
+      queryClient.invalidateQueries({ queryKey: ['pedidos', 'abonos', variables.data.pedido_id] })
     },
   })
 }


### PR DESCRIPTION
## Summary
- trigger refetch of a pedido's abonos when an abono is registrado to keep the UI in sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc02d885cc832580c4364e13286a7f